### PR TITLE
Fix screenshot unicode handling

### DIFF
--- a/src/libtrx/screenshot.c
+++ b/src/libtrx/screenshot.c
@@ -41,7 +41,7 @@ static char *M_CleanScreenshotTitle(const char *const source)
             continue;
         }
 
-        const size_t char_size = String_GetCharByteSize(out);
+        const size_t char_size = String_GetCharByteSize(source + i);
         if (char_size != 1
             || strchr(sensitive_characters, source[i]) == nullptr) {
             memcpy(out, source + i, char_size);


### PR DESCRIPTION
## Summary
- fix screenshot sanitizer to read UTF-8 char size from source string

## Testing
- `clang-format -i src/libtrx/screenshot.c`
- ❌ `pre-commit run --files src/libtrx/screenshot.c` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688505b807748327b29fac1faa4bbdc8