### PR TITLE
Preserve rotation and positioning for diagonal ledge hangs

### DIFF
--- a/src/trx/game/lara/col.c
+++ b/src/trx/game/lara/col.c
@@ -136,14 +136,17 @@ bool Lara_Col_IsDiagonalLedge(const COLL_INFO *const coll)
 
     const int32_t left_floor = coll->side_left2.floor;
     const int32_t right_floor = coll->side_right2.floor;
-    const bool left_void = left_floor == NO_HEIGHT;
-    const bool right_void = right_floor == NO_HEIGHT;
-
-    if (left_void != right_void) {
-        return true;
+    if (left_floor == NO_HEIGHT || right_floor == NO_HEIGHT) {
+        return false;
     }
 
-    if (left_void || right_void) {
+    const int32_t front_floor = coll->side_front.floor;
+    if (front_floor == NO_HEIGHT) {
+        return false;
+    }
+
+    if (ABS(left_floor - front_floor) > STEP_L * 2
+        || ABS(right_floor - front_floor) > STEP_L * 2) {
         return false;
     }
 

--- a/src/trx/game/lara/col.c
+++ b/src/trx/game/lara/col.c
@@ -140,16 +140,6 @@ bool Lara_Col_IsDiagonalLedge(const COLL_INFO *const coll)
         return false;
     }
 
-    const int32_t front_floor = coll->side_front.floor;
-    if (front_floor == NO_HEIGHT) {
-        return false;
-    }
-
-    if (ABS(left_floor - front_floor) > STEP_L * 2
-        || ABS(right_floor - front_floor) > STEP_L * 2) {
-        return false;
-    }
-
     return ABS(left_floor - right_floor) >= SLOPE_DIF;
 }
 

--- a/src/trx/game/lara/col.c
+++ b/src/trx/game/lara/col.c
@@ -119,6 +119,37 @@ void Lara_Col_GetInfo(const ITEM *const item, COLL_INFO *const coll)
         LARA_HEIGHT);
 }
 
+bool Lara_Col_IsDiagonalLedge(const COLL_INFO *const coll)
+{
+    const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
+        || coll->side_front.type == HT_SPLIT_TRI;
+    const bool left_diagonal =
+        coll->side_left2.type == HT_DIAGONAL
+        || coll->side_left2.type == HT_SPLIT_TRI;
+    const bool right_diagonal =
+        coll->side_right2.type == HT_DIAGONAL
+        || coll->side_right2.type == HT_SPLIT_TRI;
+
+    if (!front_diagonal && !left_diagonal && !right_diagonal) {
+        return false;
+    }
+
+    const int32_t left_floor = coll->side_left2.floor;
+    const int32_t right_floor = coll->side_right2.floor;
+    const bool left_void = left_floor == NO_HEIGHT;
+    const bool right_void = right_floor == NO_HEIGHT;
+
+    if (left_void != right_void) {
+        return true;
+    }
+
+    if (left_void || right_void) {
+        return false;
+    }
+
+    return ABS(left_floor - right_floor) >= SLOPE_DIF;
+}
+
 void Lara_Col_Shift(COLL_INFO *const coll)
 {
     ITEM *const lara_item = Lara_GetItem();

--- a/src/trx/game/lara/col.h
+++ b/src/trx/game/lara/col.h
@@ -24,6 +24,7 @@ bool Lara_Col_TestCeiling(ITEM *item, const COLL_INFO *coll);
 bool Lara_Col_TestHangSwingIn(const ITEM *item, int16_t angle);
 EDGE_CATCH Lara_Col_TestEdgeCatch(
     const ITEM *item, const COLL_INFO *coll, int32_t *edge);
+bool Lara_Col_IsDiagonalLedge(const COLL_INFO *coll);
 bool Lara_Col_Fallen(ITEM *item, const COLL_INFO *coll);
 void Lara_Col_DeflectEdgeJump(ITEM *item, COLL_INFO *coll);
 bool Lara_Col_LandedBad(ITEM *item);

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -229,7 +229,7 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
     coll->bad_neg = NO_BAD_NEG;
     coll->bad_ceiling = 0;
     Lara_Col_GetInfo(item, coll);
-    const bool flag = coll->side_front.floor < 200;
+    const bool initial_front_close = coll->side_front.floor < 200;
 
     item->gravity = false;
     item->fall_speed = 0;
@@ -247,6 +247,12 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
     coll->bad_neg = -STEPUP_HEIGHT;
     coll->bad_ceiling = 0;
     Lara_Col_GetInfo(item, coll);
+
+    const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
+    const bool front_close = diagonal_ledge ? false : initial_front_close;
+    const bool valid_coll_type = coll->coll_type == COLL_FRONT
+        || (diagonal_ledge
+            && (coll->coll_type == COLL_LEFT || coll->coll_type == COLL_RIGHT));
 
     if (lara->climb_status) {
         if (!g_Input.action || item->hit_points <= 0) {
@@ -292,7 +298,7 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
     }
 
     if (!g_Input.action || item->hit_points <= 0
-        || coll->side_front.floor > 0) {
+        || (coll->side_front.floor > 0 && !diagonal_ledge)) {
         item->goal_anim_state = LS(LS_JUMP_UP);
         item->current_anim_state = LS(LS_JUMP_UP);
         Item_SwitchToAnim(item, LA(LA_JUMP_UP), M_LF_STOP_HANG);
@@ -315,8 +321,8 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
     const int32_t hdif = coll->side_front.floor - bounds->min.y;
 
     if ((ABS(coll->side_left2.floor - coll->side_right2.floor) >= SLOPE_DIF
-         && !Lara_Col_IsDiagonalLedge(coll))
-        || coll->side_mid.ceiling >= 0 || coll->coll_type != COLL_FRONT || flag
+         && !diagonal_ledge)
+        || coll->side_mid.ceiling >= 0 || !valid_coll_type || front_close
         || coll->hit_static || hdif < -SLOPE_DIF || hdif > SLOPE_DIF) {
         item->pos = coll->old;
         if (item->current_anim_state == LS(LS_SHIMMY_LEFT)
@@ -328,19 +334,24 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
         return;
     }
 
-    switch (dir) {
-    case DIR_NORTH:
-    case DIR_SOUTH:
-        item->pos.z += coll->shift.z;
-        break;
-
-    case DIR_EAST:
-    case DIR_WEST:
+    if (diagonal_ledge) {
         item->pos.x += coll->shift.x;
-        break;
+        item->pos.z += coll->shift.z;
+    } else {
+        switch (dir) {
+        case DIR_NORTH:
+        case DIR_SOUTH:
+            item->pos.z += coll->shift.z;
+            break;
 
-    default:
-        break;
+        case DIR_EAST:
+        case DIR_WEST:
+            item->pos.x += coll->shift.x;
+            break;
+
+        default:
+            break;
+        }
     }
 
     if (g_TRVersion >= 2 || (hdif >= -STEP_L && hdif <= STEP_L)) {

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -525,9 +525,16 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
     }
 
     const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
-    const int32_t pullup_floor = diagonal_ledge
-        ? MIN(coll->side_left2.floor, coll->side_right2.floor)
-        : coll->side_front.floor;
+    int32_t pullup_floor = coll->side_front.floor;
+    if (diagonal_ledge) {
+        const int16_t base_angle =
+            Math_DirectionToAngle(Math_GetDirection(item->rot.y));
+        const int32_t diff =
+            ((int32_t)(item->rot.y - base_angle + DEG_180) % DEG_360)
+            - DEG_180;
+        pullup_floor =
+            diff > 0 ? coll->side_right2.floor : coll->side_left2.floor;
+    }
     const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
         || coll->side_front.type == HT_SPLIT_TRI;
     const bool front_clear =

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -871,7 +871,11 @@ bool Lara_Col_TestVault(ITEM *const item, COLL_INFO *const coll)
         return false;
     }
 
-    const DIRECTION dir = Math_GetDirectionCone(item->rot.y, M_VAULT_ANGLE);
+    const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
+    DIRECTION dir = Math_GetDirectionCone(item->rot.y, M_VAULT_ANGLE);
+    if (dir == DIR_UNKNOWN && diagonal_ledge) {
+        dir = Math_GetDirection(item->rot.y);
+    }
     if (dir == DIR_UNKNOWN) {
         return false;
     }
@@ -883,7 +887,8 @@ bool Lara_Col_TestVault(ITEM *const item, COLL_INFO *const coll)
     const int32_t right_ceiling = coll->side_right2.ceiling;
     const int32_t front_floor = coll->side_front.floor;
     const int32_t front_ceiling = coll->side_front.ceiling;
-    const bool slope = ABS(left_floor - right_floor) >= SLOPE_DIF;
+    const bool slope =
+        !diagonal_ledge && ABS(left_floor - right_floor) >= SLOPE_DIF;
     const int32_t mid = STEP_L / 2;
     const ROOM *const room = Room_Get(item->room_num);
 

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -533,8 +533,6 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
     }
 
     const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
-    const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
-        || coll->side_front.type == HT_SPLIT_TRI;
     const bool front_clear =
         coll->side_front.floor - coll->side_front.ceiling >= 0;
     const bool side_clear =

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -524,11 +524,16 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
         return;
     }
 
+    const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
+    const bool front_clear =
+        coll->side_front.floor - coll->side_front.ceiling >= 0;
+    const bool side_clear =
+        coll->side_left2.floor - coll->side_left2.ceiling >= 0
+        && coll->side_right2.floor - coll->side_right2.ceiling >= 0;
+
     if (g_Input.forward) {
         if (coll->side_front.floor > -850 && coll->side_front.floor < -650
-            && coll->side_front.floor - coll->side_front.ceiling >= 0
-            && coll->side_left2.floor - coll->side_left2.ceiling >= 0
-            && coll->side_right2.floor - coll->side_right2.ceiling >= 0
+            && front_clear && (diagonal_ledge || side_clear)
             && !coll->hit_static) {
             item->goal_anim_state = LS(g_Input.slow ? LS_GYMNAST : LS_PULL_UP);
             return;
@@ -546,8 +551,9 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
     if (g_TRVersion == 3 && (g_Input.forward || g_Input.crouch)
         && coll->side_front.floor > -850 && coll->side_front.floor < -650
         && coll->side_front.floor - coll->side_front.ceiling >= -256
-        && coll->side_left2.floor - coll->side_left2.ceiling >= -256
-        && coll->side_right2.floor - coll->side_right2.ceiling >= -256
+        && (diagonal_ledge
+            || (coll->side_left2.floor - coll->side_left2.ceiling >= -256
+                && coll->side_right2.floor - coll->side_right2.ceiling >= -256))
         && !coll->hit_static) {
         item->goal_anim_state = LS(LS_CLIMB_TO_CRAWL);
         item->required_anim_state = LS(LS_CROUCH_IDLE);

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -238,22 +238,10 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
 
     const DIRECTION dir = Math_GetDirection(item->rot.y);
     const int32_t hang_test_shift = g_TRVersion >= 3 ? 4 : 2;
-    switch (dir) {
-    case DIR_NORTH:
-        item->pos.z += hang_test_shift;
-        break;
-    case DIR_EAST:
-        item->pos.x += hang_test_shift;
-        break;
-    case DIR_SOUTH:
-        item->pos.z -= hang_test_shift;
-        break;
-    case DIR_WEST:
-        item->pos.x -= hang_test_shift;
-        break;
-    default:
-        break;
-    }
+    item->pos.x +=
+        (Math_Sin(item->rot.y) * hang_test_shift) >> W2V_SHIFT;
+    item->pos.z +=
+        (Math_Cos(item->rot.y) * hang_test_shift) >> W2V_SHIFT;
 
     coll->bad_pos = NO_BAD_POS;
     coll->bad_neg = -STEPUP_HEIGHT;
@@ -326,7 +314,8 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
     const int32_t hdif = coll->side_front.floor - bounds->min.y;
 
-    if (ABS(coll->side_left2.floor - coll->side_right2.floor) >= SLOPE_DIF
+    if ((ABS(coll->side_left2.floor - coll->side_right2.floor) >= SLOPE_DIF
+         && !Lara_Col_IsDiagonalLedge(coll))
         || coll->side_mid.ceiling >= 0 || coll->coll_type != COLL_FRONT || flag
         || coll->hit_static || hdif < -SLOPE_DIF || hdif > SLOPE_DIF) {
         item->pos = coll->old;

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -249,14 +249,6 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
     Lara_Col_GetInfo(item, coll);
 
     const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
-    const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
-        || coll->side_front.type == HT_SPLIT_TRI;
-    const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
-        || coll->side_front.type == HT_SPLIT_TRI;
-    const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
-        || coll->side_front.type == HT_SPLIT_TRI;
-    const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
-        || coll->side_front.type == HT_SPLIT_TRI;
     const bool front_close = diagonal_ledge ? false : initial_front_close;
     const bool valid_coll_type = coll->coll_type == COLL_FRONT
         || (diagonal_ledge
@@ -533,6 +525,11 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
     }
 
     const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
+    const int32_t pullup_floor = diagonal_ledge
+        ? (coll->side_left2.floor + coll->side_right2.floor) / 2
+        : coll->side_front.floor;
+    const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
+        || coll->side_front.type == HT_SPLIT_TRI;
     const bool front_clear =
         coll->side_front.floor - coll->side_front.ceiling >= 0;
     const bool side_clear =
@@ -540,7 +537,7 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
         && coll->side_right2.floor - coll->side_right2.ceiling >= 0;
 
     if (g_Input.forward) {
-        if (coll->side_front.floor > -850 && coll->side_front.floor < -650
+        if (pullup_floor > -850 && pullup_floor < -650
             && front_clear && (diagonal_ledge || front_diagonal || side_clear)
             && !coll->hit_static) {
             item->goal_anim_state = LS(g_Input.slow ? LS_GYMNAST : LS_PULL_UP);
@@ -557,7 +554,7 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
     }
 
     if (g_TRVersion == 3 && (g_Input.forward || g_Input.crouch)
-        && coll->side_front.floor > -850 && coll->side_front.floor < -650
+        && pullup_floor > -850 && pullup_floor < -650
         && coll->side_front.floor - coll->side_front.ceiling >= -256
         && (diagonal_ledge || front_diagonal
             || (coll->side_left2.floor - coll->side_left2.ceiling >= -256

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -249,6 +249,14 @@ void Lara_Col_HangTest(ITEM *const item, COLL_INFO *const coll)
     Lara_Col_GetInfo(item, coll);
 
     const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
+    const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
+        || coll->side_front.type == HT_SPLIT_TRI;
+    const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
+        || coll->side_front.type == HT_SPLIT_TRI;
+    const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
+        || coll->side_front.type == HT_SPLIT_TRI;
+    const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
+        || coll->side_front.type == HT_SPLIT_TRI;
     const bool front_close = diagonal_ledge ? false : initial_front_close;
     const bool valid_coll_type = coll->coll_type == COLL_FRONT
         || (diagonal_ledge
@@ -525,6 +533,8 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
     }
 
     const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
+    const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
+        || coll->side_front.type == HT_SPLIT_TRI;
     const bool front_clear =
         coll->side_front.floor - coll->side_front.ceiling >= 0;
     const bool side_clear =
@@ -533,7 +543,7 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
 
     if (g_Input.forward) {
         if (coll->side_front.floor > -850 && coll->side_front.floor < -650
-            && front_clear && (diagonal_ledge || side_clear)
+            && front_clear && (diagonal_ledge || front_diagonal || side_clear)
             && !coll->hit_static) {
             item->goal_anim_state = LS(g_Input.slow ? LS_GYMNAST : LS_PULL_UP);
             return;
@@ -551,7 +561,7 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
     if (g_TRVersion == 3 && (g_Input.forward || g_Input.crouch)
         && coll->side_front.floor > -850 && coll->side_front.floor < -650
         && coll->side_front.floor - coll->side_front.ceiling >= -256
-        && (diagonal_ledge
+        && (diagonal_ledge || front_diagonal
             || (coll->side_left2.floor - coll->side_left2.ceiling >= -256
                 && coll->side_right2.floor - coll->side_right2.ceiling >= -256))
         && !coll->hit_static) {

--- a/src/trx/game/lara/col/climb.c
+++ b/src/trx/game/lara/col/climb.c
@@ -526,7 +526,7 @@ static void M_Hang(ITEM *const item, COLL_INFO *const coll)
 
     const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
     const int32_t pullup_floor = diagonal_ledge
-        ? (coll->side_left2.floor + coll->side_right2.floor) / 2
+        ? MIN(coll->side_left2.floor, coll->side_right2.floor)
         : coll->side_front.floor;
     const bool front_diagonal = coll->side_front.type == HT_DIAGONAL
         || coll->side_front.type == HT_SPLIT_TRI;

--- a/src/trx/game/lara/col/crouch.c
+++ b/src/trx/game/lara/col/crouch.c
@@ -355,11 +355,17 @@ static void M_CrawlToClimb(ITEM *const item, COLL_INFO *const coll)
         return;
     }
 
-    const DIRECTION dir = Math_GetDirectionCone(item->rot.y, LARA_HANG_ANGLE);
+    const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
+    DIRECTION dir = Math_GetDirectionCone(item->rot.y, LARA_HANG_ANGLE);
+    const bool diagonal_direction = diagonal_ledge && dir == DIR_UNKNOWN;
+    if (diagonal_direction) {
+        dir = Math_GetDirection(item->rot.y);
+    }
     if (dir == DIR_UNKNOWN) {
         return;
     }
-    const int16_t angle = Math_DirectionToAngle(dir);
+    const int16_t angle =
+        diagonal_ledge ? item->rot.y : Math_DirectionToAngle(dir);
 
     if (Lara_Col_TestHangSwingIn(item, angle)) {
         lara->head_rot.x = 0;
@@ -379,33 +385,38 @@ static void M_CrawlToClimb(ITEM *const item, COLL_INFO *const coll)
     if (edge_catch == EDGE_CATCH_POS) {
         item->pos.y += coll->side_front.floor - bounds->min.y;
 
-        switch (Math_GetDirection(item->rot.y)) {
-        case DIR_NORTH:
-            item->pos.z =
-                ROUND_TO_SECTOR_END(item->pos.z) - M_CRAWL_TO_HANG_XZ_OFFSET;
+        if (diagonal_ledge) {
             item->pos.x += coll->shift.x;
-            break;
-
-        case DIR_EAST:
-            item->pos.x =
-                ROUND_TO_SECTOR_END(item->pos.x) - M_CRAWL_TO_HANG_XZ_OFFSET;
             item->pos.z += coll->shift.z;
-            break;
+        } else {
+            switch (Math_GetDirection(item->rot.y)) {
+            case DIR_NORTH:
+                item->pos.z =
+                    ROUND_TO_SECTOR_END(item->pos.z) - M_CRAWL_TO_HANG_XZ_OFFSET;
+                item->pos.x += coll->shift.x;
+                break;
 
-        case DIR_SOUTH:
-            item->pos.z =
-                ROUND_TO_SECTOR(item->pos.z) + M_CRAWL_TO_HANG_XZ_OFFSET;
-            item->pos.x += coll->shift.x;
-            break;
+            case DIR_EAST:
+                item->pos.x =
+                    ROUND_TO_SECTOR_END(item->pos.x) - M_CRAWL_TO_HANG_XZ_OFFSET;
+                item->pos.z += coll->shift.z;
+                break;
 
-        case DIR_WEST:
-            item->pos.x =
-                ROUND_TO_SECTOR(item->pos.x) + M_CRAWL_TO_HANG_XZ_OFFSET;
-            item->pos.z += coll->shift.z;
-            break;
+            case DIR_SOUTH:
+                item->pos.z =
+                    ROUND_TO_SECTOR(item->pos.z) + M_CRAWL_TO_HANG_XZ_OFFSET;
+                item->pos.x += coll->shift.x;
+                break;
 
-        default:
-            break;
+            case DIR_WEST:
+                item->pos.x =
+                    ROUND_TO_SECTOR(item->pos.x) + M_CRAWL_TO_HANG_XZ_OFFSET;
+                item->pos.z += coll->shift.z;
+                break;
+
+            default:
+                break;
+            }
         }
     } else {
         item->pos.y = edge - bounds->min.y;

--- a/src/trx/game/lara/col/jump.c
+++ b/src/trx/game/lara/col/jump.c
@@ -34,6 +34,10 @@ EDGE_CATCH Lara_Col_TestEdgeCatch(
         return EDGE_CATCH_NEG;
     }
 
+    if (Lara_Col_IsDiagonalLedge(coll)) {
+        return EDGE_CATCH_POS;
+    }
+
     return ABS(coll->side_left2.floor - coll->side_right2.floor) < SLOPE_DIF
         ? EDGE_CATCH_POS
         : EDGE_CATCH_NONE;
@@ -105,11 +109,17 @@ static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
         return false;
     }
 
-    const DIRECTION dir = Math_GetDirectionCone(item->rot.y, LARA_HANG_ANGLE);
+    const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
+    DIRECTION dir = Math_GetDirectionCone(item->rot.y, LARA_HANG_ANGLE);
+    const bool diagonal_direction = diagonal_ledge && dir == DIR_UNKNOWN;
+    if (diagonal_direction) {
+        dir = Math_GetDirection(item->rot.y);
+    }
     if (dir == DIR_UNKNOWN) {
         return false;
     }
-    const int16_t angle = Math_DirectionToAngle(dir);
+    const int16_t angle =
+        diagonal_ledge ? item->rot.y : Math_DirectionToAngle(dir);
 
     if (Lara_Col_TestHangSwingIn(item, angle)) {
         Item_SwitchToAnim(item, LA(LA_REACH_TO_THIN_LEDGE), 0);
@@ -123,31 +133,36 @@ static bool M_TestHangJump(ITEM *const item, COLL_INFO *const coll)
     const BOUNDS_16 *const bounds = Item_GetBoundsAccurate(item);
     if (edge_catch == EDGE_CATCH_POS) {
         item->pos.y += coll->side_front.floor - bounds->min.y;
-        switch (Math_GetDirection(angle)) {
-        case DIR_NORTH:
-            item->pos.z = ROUND_TO_SECTOR_END(item->pos.z) - LARA_RADIUS;
-            item->pos.x += coll->shift.x;
-            break;
-
-        case DIR_EAST:
-            item->pos.x = ROUND_TO_SECTOR_END(item->pos.x) - LARA_RADIUS;
-            item->pos.z += coll->shift.z;
-            break;
-
-        case DIR_SOUTH:
-            item->pos.z = ROUND_TO_SECTOR(item->pos.z) + LARA_RADIUS;
-            item->pos.x += coll->shift.x;
-            break;
-
-        case DIR_WEST:
-            item->pos.x = ROUND_TO_SECTOR(item->pos.x) + LARA_RADIUS;
-            item->pos.z += coll->shift.z;
-            break;
-
-        default:
+        if (diagonal_ledge) {
             item->pos.x += coll->shift.x;
             item->pos.z += coll->shift.z;
-            break;
+        } else {
+            switch (Math_GetDirection(angle)) {
+            case DIR_NORTH:
+                item->pos.z = ROUND_TO_SECTOR_END(item->pos.z) - LARA_RADIUS;
+                item->pos.x += coll->shift.x;
+                break;
+
+            case DIR_EAST:
+                item->pos.x = ROUND_TO_SECTOR_END(item->pos.x) - LARA_RADIUS;
+                item->pos.z += coll->shift.z;
+                break;
+
+            case DIR_SOUTH:
+                item->pos.z = ROUND_TO_SECTOR(item->pos.z) + LARA_RADIUS;
+                item->pos.x += coll->shift.x;
+                break;
+
+            case DIR_WEST:
+                item->pos.x = ROUND_TO_SECTOR(item->pos.x) + LARA_RADIUS;
+                item->pos.z += coll->shift.z;
+                break;
+
+            default:
+                item->pos.x += coll->shift.x;
+                item->pos.z += coll->shift.z;
+                break;
+            }
         }
     } else {
         item->pos.y = edge - bounds->min.y;
@@ -200,11 +215,17 @@ static bool M_TestHangJumpUp(ITEM *const item, COLL_INFO *const coll)
         return false;
     }
 
-    const DIRECTION dir = Math_GetDirectionCone(item->rot.y, LARA_HANG_ANGLE);
+    const bool diagonal_ledge = Lara_Col_IsDiagonalLedge(coll);
+    DIRECTION dir = Math_GetDirectionCone(item->rot.y, LARA_HANG_ANGLE);
+    const bool diagonal_direction = diagonal_ledge && dir == DIR_UNKNOWN;
+    if (diagonal_direction) {
+        dir = Math_GetDirection(item->rot.y);
+    }
     if (dir == DIR_UNKNOWN) {
         return false;
     }
-    const int16_t angle = Math_DirectionToAngle(dir);
+    const int16_t angle =
+        diagonal_ledge ? item->rot.y : Math_DirectionToAngle(dir);
 
     item->goal_anim_state = LS(LS_HANG);
     item->current_anim_state = LS(LS_HANG);


### PR DESCRIPTION
### Motivation
- Diagonal or split ledges were being rejected or causing Lara to snap to cardinal directions, leading to brief grabs and immediate falls. 
- The intent is to detect diagonal/split geometry and let hang/edge flows accept those surfaces while preserving Lara's facing angle and correct placement. 

### Description
- Add detection of diagonal/split ledges via `Lara_Col_IsDiagonalLedge` (declared in `col.h` and implemented in `col.c`).
- Treat diagonal ledges as an edge catch by returning `EDGE_CATCH_POS` from `Lara_Col_TestEdgeCatch` when applicable.
- Relax hang-direction gating by falling back from `Math_GetDirectionCone` to `Math_GetDirection` for diagonal ledges and preserve `item->rot.y` (instead of snapping to `Math_DirectionToAngle`) during jump and crawl to hang flows, and avoid sector-edge rounding by applying `coll->shift.x`/`coll->shift.z` directly for diagonal cases.
- Update hang test logic in `climb.c` to use `Math_Sin`/`Math_Cos`-based position shifts and allow diagonal slopes in the slope-difference check.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69640d6739148327bf2cde375cd522e0)